### PR TITLE
Fix CMake "unknown arguments" error.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,7 +17,7 @@ option(BUILD_SHARED_LIBS "build shared libraries instead of static libraries"
 
 # determine lib suffix
 get_property(LIB64 GLOBAL PROPERTY FIND_LIBRARY_USE_LIB64_PATHS)
-if (${LIB64} STREQUAL "TRUE")
+if ("${LIB64}" STREQUAL "TRUE")
     set(LIBSUFFIX 64)
 else()
     set(LIBSUFFIX "")


### PR DESCRIPTION
I ran into this problem when using mingw-w64 on Debian 7 to cross-compile.
